### PR TITLE
Update test_files_folders_exists.py

### DIFF
--- a/GEM_data_repo_tests/test_files_folders_exists.py
+++ b/GEM_data_repo_tests/test_files_folders_exists.py
@@ -17,7 +17,7 @@ config = yaml.safe_load("""
     data: 
         search_pattern: [
             'data/*/*_survey_final.csv',
-            'data/*/*_survey_raw.jp*g',
+            'data/*/*_survey_raw*.jp*g',
             'data/*/Aquafluor',
             'data/*/Aquafluor/Changelog.txt',
             'data/*/DR1900',


### PR DESCRIPTION
Noticed that GEM test was failing when users uploaded e.g., 2025-12-06_survey_raw1.jpg, 2025-12-06_survey_raw2.jpg files, and I think it's failing because the current test doesn't allow for any extension behind `survey_raw`. I think adding an asterisk would solve the problem. 

For example: https://github.com/HakaiInstitute/GEM-Kit7-repository/actions/runs/23930275317